### PR TITLE
Add scroll animations and transparent header

### DIFF
--- a/src/components/Anuncios.tsx
+++ b/src/components/Anuncios.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Bell, Calendar, Info, X, Mail, CheckCircle } from 'lucide-react';
+import useScrollAnimation from '../hooks/useScrollAnimation';
 
 interface Anuncio {
   id: number;
@@ -13,6 +14,7 @@ interface Anuncio {
 }
 
 const Anuncios = () => {
+  const ref = useScrollAnimation<HTMLDivElement>();
   const [modalAbierto, setModalAbierto] = useState(false);
   const [anuncioSeleccionado, setAnuncioSeleccionado] = useState<Anuncio | null>(null);
   const [emailSuscripcion, setEmailSuscripcion] = useState('');
@@ -74,7 +76,10 @@ const Anuncios = () => {
   };
 
   return (
-    <div className="py-20 bg-gradient-to-br from-cream to-white bg-opacity-80">
+    <div
+      ref={ref}
+      className="scroll-animation py-20 bg-gradient-to-br from-cream to-white bg-opacity-80"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <div className="flex justify-center mb-6">

--- a/src/components/Contacto.tsx
+++ b/src/components/Contacto.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import { Mail, Phone, MapPin, Clock, Send, Facebook, MessageSquare, ExternalLink } from 'lucide-react';
+import useScrollAnimation from '../hooks/useScrollAnimation';
 
 const Contacto = () => {
+  const ref = useScrollAnimation<HTMLDivElement>();
   const [formData, setFormData] = useState({
     nombre: '',
     email: '',
@@ -51,7 +53,7 @@ const Contacto = () => {
   };
 
   return (
-    <div className="py-20 bg-cream bg-opacity-80">
+    <div ref={ref} className="scroll-animation py-20 bg-cream bg-opacity-80">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <div className="flex justify-center mb-6">

--- a/src/components/Eventos.tsx
+++ b/src/components/Eventos.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Calendar, MapPin, Clock, Music } from 'lucide-react';
+import useScrollAnimation from '../hooks/useScrollAnimation';
 
 interface Evento {
   id: number;
@@ -12,6 +13,7 @@ interface Evento {
 }
 
 const Eventos = () => {
+  const ref = useScrollAnimation<HTMLDivElement>();
   const eventos: Evento[] = [
     {
       id: 1,
@@ -79,7 +81,7 @@ const Eventos = () => {
   ];
 
   return (
-    <div className="py-20 bg-olive-green">
+    <div ref={ref} className="scroll-animation py-20 bg-olive-green">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <div className="flex justify-center mb-6">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,11 +33,13 @@ const Header = () => {
   };
 
   return (
-    <header className={`sticky top-0 z-50 transition-all duration-300 ${
-      isScrolled 
-        ? 'bg-olive-green bg-opacity-90 backdrop-blur-md shadow-lg' 
-        : 'bg-olive-green bg-opacity-70 backdrop-blur-sm'
-    }`}>
+    <header
+      className={`sticky top-0 z-50 transition-all duration-300 ${
+        isScrolled
+          ? 'bg-olive-green bg-opacity-90 backdrop-blur-md shadow-lg'
+          : 'bg-transparent'
+      }`}
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-3">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { ArrowRight, Calendar, BookOpen } from 'lucide-react';
+import useScrollAnimation from '../hooks/useScrollAnimation';
 
 const Hero = () => {
+  const ref = useScrollAnimation<HTMLDivElement>();
+
   const scrollToSection = (href: string) => {
     const element = document.querySelector(href);
     if (element) {
@@ -10,7 +13,10 @@ const Hero = () => {
   };
 
   return (
-    <div className="bg-gradient-to-br from-olive-green to-sky-blue min-h-screen flex items-center">
+    <div
+      ref={ref}
+      className="scroll-animation bg-gradient-to-br from-olive-green to-sky-blue min-h-screen flex items-center"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
         <div className="text-center">
           <h1 className="text-5xl md:text-7xl font-bold text-white mb-6">

--- a/src/components/Historia.tsx
+++ b/src/components/Historia.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Clock, MapPin, Users, Book } from 'lucide-react';
+import useScrollAnimation from '../hooks/useScrollAnimation';
 
 const Historia = () => {
+  const ref = useScrollAnimation<HTMLDivElement>();
   return (
-    <div className="py-20 bg-cream">
+    <div ref={ref} className="scroll-animation py-20 bg-cream">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-5xl font-bold text-olive-green mb-6">Nuestra Historia</h2>

--- a/src/components/Servicios.tsx
+++ b/src/components/Servicios.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Phone, Globe, Mail, GraduationCap, Heart, Droplets, Users, Clock, MapPin } from 'lucide-react';
+import useScrollAnimation from '../hooks/useScrollAnimation';
 
 interface Servicio {
   id: number;
@@ -17,6 +18,7 @@ interface Servicio {
 }
 
 const Servicios = () => {
+  const ref = useScrollAnimation<HTMLDivElement>();
   const servicios: Servicio[] = [
     {
       id: 1,
@@ -163,7 +165,7 @@ const Servicios = () => {
   };
 
   return (
-    <div className="py-20 bg-cream bg-opacity-80">
+    <div ref={ref} className="scroll-animation py-20 bg-cream bg-opacity-80">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <div className="flex justify-center mb-6">

--- a/src/components/Traductor.tsx
+++ b/src/components/Traductor.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import { Languages, ArrowRightLeft, Volume2, Copy } from 'lucide-react';
+import useScrollAnimation from '../hooks/useScrollAnimation';
 
 const Traductor = () => {
+  const ref = useScrollAnimation<HTMLDivElement>();
   const [textoEspanol, setTextoEspanol] = useState('');
   const [textoHnahnu, setTextoHnahnu] = useState('');
   const [direccion, setDireccion] = useState<'esp-hna' | 'hna-esp'>('esp-hna');
@@ -81,7 +83,10 @@ const Traductor = () => {
   ];
 
   return (
-    <div className="py-20 bg-gradient-to-br from-sky-blue to-olive-green">
+    <div
+      ref={ref}
+      className="scroll-animation py-20 bg-gradient-to-br from-sky-blue to-olive-green"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <div className="flex justify-center mb-6">

--- a/src/hooks/useScrollAnimation.tsx
+++ b/src/hooks/useScrollAnimation.tsx
@@ -1,0 +1,28 @@
+import { useRef, useEffect } from 'react';
+
+const useScrollAnimation = <T extends HTMLElement>() => {
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          element.classList.add('visible');
+        } else {
+          element.classList.remove('visible');
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return ref;
+};
+
+export default useScrollAnimation;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.scroll-animation {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.scroll-animation.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+


### PR DESCRIPTION
## Summary
- make the header transparent until scrolling down
- animate elements when they enter or leave the viewport
- add a custom hook `useScrollAnimation`
- define `.scroll-animation` utility classes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510ce2da908332903bb119f702c788