### PR TITLE
Add carousel and tweak header

### DIFF
--- a/src/assets/hero-carousel/README.md
+++ b/src/assets/hero-carousel/README.md
@@ -1,0 +1,1 @@
+Place images for the hero carousel in this folder.

--- a/src/assets/historia/README.md
+++ b/src/assets/historia/README.md
@@ -1,0 +1,1 @@
+Place two images for the Historia section here.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,7 @@ const Header = () => {
       className={`sticky top-0 z-50 transition-all duration-300 ${
         isScrolled
           ? 'bg-olive-green bg-opacity-90 backdrop-blur-md shadow-lg'
-          : 'bg-transparent'
+          : 'bg-olive-green bg-opacity-50 backdrop-blur-md'
       }`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ArrowRight, Calendar, BookOpen } from 'lucide-react';
 import useScrollAnimation from '../hooks/useScrollAnimation';
+import HeroCarousel from './HeroCarousel';
 
 const Hero = () => {
   const ref = useScrollAnimation<HTMLDivElement>();
@@ -17,8 +18,9 @@ const Hero = () => {
       ref={ref}
       className="scroll-animation bg-gradient-to-br from-olive-green to-sky-blue min-h-screen flex items-center"
     >
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
-        <div className="text-center">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 w-full">
+        <div className="flex flex-col-reverse md:flex-row items-center md:space-x-12">
+          <div className="text-center md:text-left md:w-1/2">
           <h1 className="text-5xl md:text-7xl font-bold text-white mb-6">
             Bienvenidos a
             <br />
@@ -64,6 +66,11 @@ const Hero = () => {
               <h3 className="text-2xl font-bold text-white mb-4">Progreso</h3>
               <p className="text-cream">Avanzamos hacia un futuro próspero</p>
             </div>
+          </div>
+          </div>
+
+          <div className="mb-10 md:mb-0 md:w-1/2 w-full">
+            <HeroCarousel />
           </div>
         </div>
       </div>

--- a/src/components/HeroCarousel.tsx
+++ b/src/components/HeroCarousel.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+// Import all images from the hero-carousel assets folder
+const images = Object.values(
+  import.meta.glob('../assets/hero-carousel/*.{jpg,jpeg,png,webp}', {
+    eager: true,
+    as: 'url'
+  })
+) as string[];
+
+const HeroCarousel = () => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (images.length <= 1) return;
+    const interval = setInterval(() => {
+      setIndex((prev) => (prev + 1) % images.length);
+    }, 4000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (images.length === 0) return null;
+
+  return (
+    <div className="w-full h-64 md:h-96 overflow-hidden rounded-2xl shadow-lg">
+      <img
+        src={images[index]}
+        alt={`Imagen carrusel ${index + 1}`}
+        className="w-full h-full object-cover transition-opacity duration-700"
+      />
+    </div>
+  );
+};
+
+export default HeroCarousel;

--- a/src/components/Historia.tsx
+++ b/src/components/Historia.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { Clock, MapPin, Users, Book } from 'lucide-react';
 import useScrollAnimation from '../hooks/useScrollAnimation';
 
+const historiaImages = Object.values(
+  import.meta.glob('../assets/historia/*.{jpg,jpeg,png,webp}', {
+    eager: true,
+    as: 'url',
+  })
+) as string[];
+
 const Historia = () => {
   const ref = useScrollAnimation<HTMLDivElement>();
   return (
@@ -97,15 +104,15 @@ const Historia = () => {
               </div>
             </div>
 
-            <div className="bg-white rounded-2xl overflow-hidden shadow-lg">
-              <div className="h-64 bg-gradient-to-r from-terracota to-olive-green flex items-center justify-center">
-                <div className="text-center text-white">
-                  <MapPin size={48} className="mx-auto mb-4" />
-                  <p className="text-lg font-semibold">Patria Nueva</p>
-                  <p className="text-sm opacity-90">Antiguamente Barrio del Capulín</p>
-                  <p className="text-xs opacity-75 mt-2">Santiago de Anaya, Hidalgo</p>
-                </div>
-              </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {historiaImages.map((src, idx) => (
+                <img
+                  key={idx}
+                  src={src}
+                  alt={`Historia ${idx + 1}`}
+                  className="w-full h-48 object-cover rounded-2xl shadow-md"
+                />
+              ))}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- create `HeroCarousel` component that loads images from the `hero-carousel` directory
- show the carousel next to the hero text
- replace the old "Patria Nueva" card in `Historia` with two local images
- make the header semi‑transparent green

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851107c6170833286759226c750e92c