### PR TITLE
Implement carousels for announcements and events

### DIFF
--- a/src/assets/anuncios-carousel/anuncio1/README.md
+++ b/src/assets/anuncios-carousel/anuncio1/README.md
@@ -1,0 +1,1 @@
+Coloca aquí las imágenes del carrusel para el anuncio 1.

--- a/src/assets/eventos-carousel/evento1/README.md
+++ b/src/assets/eventos-carousel/evento1/README.md
@@ -1,0 +1,1 @@
+Imágenes del carrusel para el evento 1.

--- a/src/assets/eventos-carousel/evento2/README.md
+++ b/src/assets/eventos-carousel/evento2/README.md
@@ -1,0 +1,1 @@
+Imágenes del carrusel para el evento 2.

--- a/src/assets/eventos-carousel/evento3/README.md
+++ b/src/assets/eventos-carousel/evento3/README.md
@@ -1,0 +1,1 @@
+Imágenes del carrusel para el evento 3.

--- a/src/assets/eventos-carousel/evento4/README.md
+++ b/src/assets/eventos-carousel/evento4/README.md
@@ -1,0 +1,1 @@
+Imágenes del carrusel para el evento 4.

--- a/src/assets/eventos-carousel/evento5/README.md
+++ b/src/assets/eventos-carousel/evento5/README.md
@@ -1,0 +1,1 @@
+Imágenes del carrusel para el evento 5.

--- a/src/assets/eventos-carousel/evento6/README.md
+++ b/src/assets/eventos-carousel/evento6/README.md
@@ -1,0 +1,1 @@
+Imágenes del carrusel para el evento 6.

--- a/src/assets/eventos-carousel/evento7/README.md
+++ b/src/assets/eventos-carousel/evento7/README.md
@@ -1,0 +1,1 @@
+Imágenes del carrusel para el evento 7.

--- a/src/components/Anuncios.tsx
+++ b/src/components/Anuncios.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Bell, Calendar, Info, X, Mail, CheckCircle } from 'lucide-react';
+import ImageCarousel from './ImageCarousel';
 import useScrollAnimation from '../hooks/useScrollAnimation';
 
 interface Anuncio {
@@ -9,6 +10,7 @@ interface Anuncio {
   fecha: string;
   categoria: string;
   imagen: string;
+  imagenes?: string[];
   contenidoCompleto: string;
   detalles?: string[];
 }
@@ -21,6 +23,14 @@ const Anuncios = () => {
   const [suscripcionExitosa, setSuscripcionExitosa] = useState(false);
   const [mostrarSuscripcion, setMostrarSuscripcion] = useState(false);
 
+  // Cargar imágenes del carrusel para el anuncio 1
+  const anuncio1Images = Object.values(
+    import.meta.glob('../assets/anuncios-carousel/anuncio1/*.{jpg,jpeg,png,webp}', {
+      eager: true,
+      as: 'url'
+    })
+  ) as string[];
+
   const anuncios: Anuncio[] = [
     {
       id: 1,
@@ -28,7 +38,8 @@ const Anuncios = () => {
       resumen: "¡La fiesta más grande del año! Tradición que late con fuerza en el corazón del Mezquital.",
       fecha: "1 de Julio, 2025",
       categoria: "Feria Patronal",
-      imagen: "https://images.pexels.com/photos/1190297/pexels-photo-1190297.jpeg?auto=compress&cs=tinysrgb&w=800",
+      imagen: anuncio1Images[0] || "",
+      imagenes: anuncio1Images,
       contenidoCompleto: "¡La fiesta más grande del año! Tradición que late con fuerza: coronación de la reina, bailes populares y ambiente familiar en el corazón del Mezquital. ¡Nos vemos en la feria!",
       detalles: [
         "Ubicación: Centro de Patria Nueva, Santiago de Anaya, Hidalgo",
@@ -180,12 +191,11 @@ const Anuncios = () => {
         {/* Modal */}
         {modalAbierto && anuncioSeleccionado && (
           <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-            <div className="bg-white rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+            <div className="bg-white bg-opacity-80 backdrop-blur-md rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
               <div className="relative">
-                <img 
-                  src={anuncioSeleccionado.imagen} 
-                  alt={anuncioSeleccionado.titulo}
-                  className="w-full h-64 object-cover rounded-t-2xl"
+                <ImageCarousel
+                  images={anuncioSeleccionado.imagenes || [anuncioSeleccionado.imagen]}
+                  className="w-full h-64 md:h-96"
                 />
                 <button
                   onClick={cerrarModal}
@@ -197,7 +207,7 @@ const Anuncios = () => {
                   {anuncioSeleccionado.categoria}
                 </div>
               </div>
-              
+
               <div className="p-8">
                 <div className="flex items-center text-sm text-gray-500 mb-4">
                   <Calendar size={16} className="mr-2" />

--- a/src/components/Eventos.tsx
+++ b/src/components/Eventos.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Calendar, Music } from 'lucide-react';
+import React, { useState } from 'react';
+import { Calendar, Music, X } from 'lucide-react';
+import ImageCarousel from './ImageCarousel';
 import useScrollAnimation from '../hooks/useScrollAnimation';
 
 interface Evento {
@@ -8,19 +9,36 @@ interface Evento {
   fecha: string;
   descripcion: string;
   imagen: string;
+  imagenes?: string[];
   ubicacion: string;
   hora: string;
 }
 
 const Eventos = () => {
   const ref = useScrollAnimation<HTMLDivElement>();
+  const [modalAbierto, setModalAbierto] = useState(false);
+  const [eventoSeleccionado, setEventoSeleccionado] = useState<Evento | null>(null);
+
+  const eventImagesMap: Record<number, string[]> = {};
+  const imgs = import.meta.glob('../assets/eventos-carousel/evento*/*.{jpg,jpeg,png,webp}', {
+    eager: true,
+    as: 'url'
+  });
+  for (const path in imgs) {
+    const match = path.match(/eventos-carousel\/evento(\d+)\//);
+    if (match) {
+      const id = Number(match[1]);
+      (eventImagesMap[id] ??= []).push(imgs[path] as string);
+    }
+  }
   const eventos: Evento[] = [
     {
       id: 1,
       nombre: "Fiesta de la Santa Cruz",
       fecha: "3 de Mayo",
       descripcion: "Celebración en el cerro Xitphe con bendición de cruces, danzas autóctonas y un ambiente de fe y tradición que une a la comunidad.",
-      imagen: "/eventos/evento1.jpg",
+      imagen: eventImagesMap[1]?.[0] || "",
+      imagenes: eventImagesMap[1],
       ubicacion: "Cerro Xitphe",
       hora: "Todo el día"
     },
@@ -29,7 +47,8 @@ const Eventos = () => {
       nombre: "Conmemoración Ejidal",
       fecha: "15 de Mayo",
       descripcion: "Desfile de tractores, música de banda y actos cívicos para recordar la entrega de parcelas de 1925; encuentro fraterno entre ejidatarios y familias.",
-      imagen: "/eventos/evento2.jpg",
+      imagen: eventImagesMap[2]?.[0] || "",
+      imagenes: eventImagesMap[2],
       ubicacion: "Centro de Patria Nueva",
       hora: "9:00 AM - 6:00 PM"
     },
@@ -38,7 +57,8 @@ const Eventos = () => {
       nombre: "Feria a \"La Preciosa Sangre de Cristo\"",
       fecha: "1 de Julio",
       descripcion: "Feria patronal con charreadas, jaripeo nocturno, juegos mecánicos, bailes populares y espectáculos de fuegos artificiales. Diversión familiar asegurada.",
-      imagen: "/eventos/evento3.jpg",
+      imagen: eventImagesMap[3]?.[0] || "",
+      imagenes: eventImagesMap[3],
       ubicacion: "Centro de Patria Nueva",
       hora: "Todo el día"
     },
@@ -47,7 +67,8 @@ const Eventos = () => {
       nombre: "Grito de Independencia",
       fecha: "15 de Septiembre",
       descripcion: "Verbena cívica con música, luces y pirotecnia que enciende el orgullo patrio y fortalece el sentido de comunidad.",
-      imagen: "/eventos/evento4.jpg",
+      imagen: eventImagesMap[4]?.[0] || "",
+      imagenes: eventImagesMap[4],
       ubicacion: "Plaza Principal",
       hora: "7:00 PM - 12:00 AM"
     },
@@ -56,7 +77,8 @@ const Eventos = () => {
       nombre: "Día de Muertos",
       fecha: "1 y 2 de Noviembre",
       descripcion: "Ofrendas, altares y visita a los panteones para honrar a nuestros seres queridos.",
-      imagen: "/eventos/evento5.jpg",
+      imagen: eventImagesMap[5]?.[0] || "",
+      imagenes: eventImagesMap[5],
       ubicacion: "Panteón y hogares",
       hora: "Todo el día"
     },
@@ -65,7 +87,8 @@ const Eventos = () => {
       nombre: "Encendido del Árbol",
       fecha: "Principios de Diciembre",
       descripcion: "Arranque oficial de la temporada navideña con luces, villancicos y un ambiente familiar que ilumina todo el corazón de Patria Nueva.",
-      imagen: "/eventos/evento6.jpg",
+      imagen: eventImagesMap[6]?.[0] || "",
+      imagenes: eventImagesMap[6],
       ubicacion: "Plaza Principal",
       hora: "6:00 PM - 9:00 PM"
     },
@@ -74,11 +97,22 @@ const Eventos = () => {
       nombre: "Feria a \"La Virgen María de Guadalupe\"",
       fecha: "10-12 de Diciembre",
       descripcion: "Festejo guadalupano con misas solemnes, danzas populares y espectáculos artísticos que reafirman nuestra fe y cultura.",
-      imagen: "/eventos/evento7.jpg",
+      imagen: eventImagesMap[7]?.[0] || "",
+      imagenes: eventImagesMap[7],
       ubicacion: "Iglesia y Plaza",
       hora: "Variable"
     }
   ];
+
+  const abrirModal = (evento: Evento) => {
+    setEventoSeleccionado(evento);
+    setModalAbierto(true);
+  };
+
+  const cerrarModal = () => {
+    setModalAbierto(false);
+    setEventoSeleccionado(null);
+  };
 
   return (
     <div ref={ref} className="scroll-animation py-20 bg-olive-green">
@@ -95,10 +129,14 @@ const Eventos = () => {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {eventos.map((evento) => (
-            <div key={evento.id} className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">
+            <div
+              key={evento.id}
+              onClick={() => abrirModal(evento)}
+              className="cursor-pointer bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
+            >
               <div className="relative h-48">
-                <img 
-                  src={evento.imagen} 
+                <img
+                  src={evento.imagen}
                   alt={evento.nombre}
                   className="w-full h-full object-cover"
                 />
@@ -128,6 +166,26 @@ const Eventos = () => {
             </div>
           ))}
         </div>
+        {modalAbierto && eventoSeleccionado && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+            <div className="bg-white bg-opacity-80 backdrop-blur-md rounded-2xl max-w-2xl w-full">
+              <div className="relative">
+                <button
+                  onClick={cerrarModal}
+                  className="absolute top-4 right-4 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70 transition-colors"
+                >
+                  <X size={20} />
+                </button>
+              </div>
+              <div className="p-6 pt-12">
+                <h2 className="text-2xl font-bold text-olive-green mb-4 text-center">
+                  {eventoSeleccionado.nombre}
+                </h2>
+                <ImageCarousel images={eventoSeleccionado.imagenes || [eventoSeleccionado.imagen]} className="w-full h-64 md:h-96" />
+              </div>
+            </div>
+          </div>
+        )}
 
         <div className="mt-16 bg-white bg-opacity-10 backdrop-blur-sm rounded-2xl p-8 text-center">
           <h3 className="text-2xl font-bold text-white mb-4">¡Participa en Nuestras Tradiciones!</h3>

--- a/src/components/HeroCarousel.tsx
+++ b/src/components/HeroCarousel.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+import ImageCarousel from './ImageCarousel';
 
 // Import all images from the hero-carousel assets folder
 const images = Object.values(
@@ -9,26 +10,10 @@ const images = Object.values(
 ) as string[];
 
 const HeroCarousel = () => {
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    if (images.length <= 1) return;
-    const interval = setInterval(() => {
-      setIndex((prev) => (prev + 1) % images.length);
-    }, 4000);
-    return () => clearInterval(interval);
-  }, []);
-
   if (images.length === 0) return null;
 
   return (
-    <div className="w-full h-64 md:h-96 overflow-hidden rounded-2xl shadow-lg">
-      <img
-        src={images[index]}
-        alt={`Imagen carrusel ${index + 1}`}
-        className="w-full h-full object-cover transition-opacity duration-700"
-      />
-    </div>
+    <ImageCarousel images={images} className="w-full h-64 md:h-96 shadow-lg" />
   );
 };
 

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+interface ImageCarouselProps {
+  images: string[];
+  className?: string;
+}
+
+const ImageCarousel: React.FC<ImageCarouselProps> = ({ images, className }) => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (images.length <= 1) return;
+    const interval = setInterval(() => {
+      setIndex((prev) => (prev + 1) % images.length);
+    }, 4000);
+    return () => clearInterval(interval);
+  }, [images]);
+
+  if (images.length === 0) return null;
+
+  return (
+    <div className={`overflow-hidden rounded-2xl ${className ?? ''}`.trim()}>
+      <img
+        src={images[index]}
+        alt={`Imagen carrusel ${index + 1}`}
+        className="w-full h-full object-cover transition-opacity duration-700"
+      />
+    </div>
+  );
+};
+
+export default ImageCarousel;


### PR DESCRIPTION
## Summary
- add generic `ImageCarousel` component
- refactor hero carousel to use `ImageCarousel`
- load images for announcements from `src/assets/anuncios-carousel`
- show a carousel in announcement modal with translucent background
- enable modal carousel for events and add placeholder folders for event images

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6852018f2c708332b58bc0b95211d440