### PR TITLE
Add carousel animation and improve anuncio images

### DIFF
--- a/src/assets/anuncios-carousel/portada/README.md
+++ b/src/assets/anuncios-carousel/portada/README.md
@@ -1,1 +1,0 @@
-Coloca aquí las imágenes de portada para los anuncios.

--- a/src/assets/anuncios-carousel/portada/README.md
+++ b/src/assets/anuncios-carousel/portada/README.md
@@ -1,0 +1,1 @@
+Coloca aquí las imágenes de portada para los anuncios.

--- a/src/assets/anuncios-portada/anuncio1/README.md
+++ b/src/assets/anuncios-portada/anuncio1/README.md
@@ -1,0 +1,1 @@
+Coloca aquí la imagen de portada para el anuncio 1.

--- a/src/components/Anuncios.tsx
+++ b/src/components/Anuncios.tsx
@@ -152,10 +152,10 @@ const Anuncios = () => {
           {anuncios.map((anuncio) => (
             <div key={anuncio.id} className="bg-white bg-opacity-95 rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 w-full max-w-md mx-auto">
               <div className="relative h-48">
-                <img 
-                  src={anuncio.imagen} 
+                <img
+                  src={anuncio.imagen}
                   alt={anuncio.titulo}
-                  className="w-full h-full object-cover"
+                  className="w-full h-full object-contain"
                 />
                 <div className={`absolute top-4 left-4 ${getCategoriaColor(anuncio.categoria)} text-white px-3 py-1 rounded-full text-sm font-semibold`}>
                   {anuncio.categoria}

--- a/src/components/Anuncios.tsx
+++ b/src/components/Anuncios.tsx
@@ -31,6 +31,14 @@ const Anuncios = () => {
     })
   ) as string[];
 
+  // Cargar imagen de portada para el anuncio 1 (estática)
+  const anuncio1Portada = Object.values(
+    import.meta.glob('../assets/anuncios-portada/anuncio1/*.{jpg,jpeg,png,webp}', {
+      eager: true,
+      as: 'url'
+    })
+  ) as string[];
+
   const anuncios: Anuncio[] = [
     {
       id: 1,
@@ -38,7 +46,7 @@ const Anuncios = () => {
       resumen: "¡La fiesta más grande del año! Tradición que late con fuerza en el corazón del Mezquital.",
       fecha: "1 de Julio, 2025",
       categoria: "Feria Patronal",
-      imagen: anuncio1Images[0] || "",
+      imagen: anuncio1Portada[0] || anuncio1Images[0] || "",
       imagenes: anuncio1Images,
       contenidoCompleto: "¡La fiesta más grande del año! Tradición que late con fuerza: coronación de la reina, bailes populares y ambiente familiar en el corazón del Mezquital. ¡Nos vemos en la feria!",
       detalles: [

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -19,12 +19,19 @@ const ImageCarousel: React.FC<ImageCarouselProps> = ({ images, className }) => {
   if (images.length === 0) return null;
 
   return (
-    <div className={`overflow-hidden rounded-2xl ${className ?? ''}`.trim()}>
-      <img
-        src={images[index]}
-        alt={`Imagen carrusel ${index + 1}`}
-        className="w-full h-full object-cover transition-opacity duration-700"
-      />
+    <div
+      className={`relative overflow-hidden rounded-2xl ${className ?? ''}`.trim()}
+    >
+      {images.map((src, i) => (
+        <img
+          key={i}
+          src={src}
+          alt={`Imagen carrusel ${i + 1}`}
+          className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-700 ${
+            i === index ? 'opacity-100' : 'opacity-0'
+          }`}
+        />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- animate the hero carousel images using a fade effect
- prevent anuncio card images from being heavily cropped
- add folder for anuncio cover images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68520f7894a8833287e1ee6511577152