### PR TITLE
Improve mobile header and hero layout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,20 +34,18 @@ const Header = () => {
 
   return (
     <header
-      className={`sticky top-0 z-50 transition-all duration-300 ${
-        isScrolled
-          ? 'bg-olive-green bg-opacity-90 backdrop-blur-md shadow-lg'
-          : 'bg-olive-green bg-opacity-50 backdrop-blur-md'
+      className={`sticky top-0 z-50 w-full bg-gradient-to-r from-terracota via-olive-green to-sky-blue transition-all duration-300 ${
+        isScrolled ? 'shadow-lg' : ''
       }`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-3">
-            <div className="w-10 h-10 bg-terracota rounded-full flex items-center justify-center">
-              <span className="text-white font-bold text-lg">PN</span>
+            <div className="w-12 h-12 bg-terracota rounded-full flex items-center justify-center">
+              <span className="text-white font-bold text-xl">PN</span>
             </div>
             <div>
-              <h1 className="text-white text-xl font-bold">Patria Nueva</h1>
+              <h1 className="text-white text-2xl font-bold">Patria Nueva</h1>
               <p className="text-sky-blue text-sm">Santiago de Anaya, Hidalgo</p>
             </div>
           </div>
@@ -68,23 +66,27 @@ const Header = () => {
             className="lg:hidden text-white p-2"
             onClick={() => setIsMenuOpen(!isMenuOpen)}
           >
-            {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
+            {isMenuOpen ? <X size={28} /> : <Menu size={28} />}
           </button>
         </div>
 
         {isMenuOpen && (
-          <div className="lg:hidden bg-olive-green bg-opacity-95 backdrop-blur-md border-t border-sky-blue border-opacity-30">
-            <nav className="py-4 space-y-2">
-              {navItems.map((item) => (
-                <button
-                  key={item.name}
-                  onClick={() => scrollToSection(item.href)}
-                  className="block w-full text-left px-4 py-2 text-white hover:bg-terracota hover:bg-opacity-50 transition-colors duration-300"
-                >
-                  {item.name}
-                </button>
-              ))}
-            </nav>
+          <div className="lg:hidden fixed inset-0 bg-gradient-to-b from-terracota via-olive-green to-sky-blue flex flex-col items-center justify-center space-y-6">
+            <button
+              className="absolute top-4 right-4 text-white p-2"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              <X size={28} />
+            </button>
+            {navItems.map((item) => (
+              <button
+                key={item.name}
+                onClick={() => scrollToSection(item.href)}
+                className="text-white text-xl font-medium hover:text-terracota transition-colors duration-300"
+              >
+                {item.name}
+              </button>
+            ))}
           </div>
         )}
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -19,7 +19,7 @@ const Hero = () => {
       className="scroll-animation bg-gradient-to-br from-olive-green to-sky-blue min-h-screen flex items-center"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 w-full">
-        <div className="flex flex-col-reverse md:flex-row items-center md:space-x-12">
+        <div className="flex flex-col md:flex-row items-center md:space-x-12">
           <div className="text-center md:text-left md:w-1/2">
           <h1 className="text-5xl md:text-7xl font-bold text-white mb-6">
             Bienvenidos a
@@ -27,9 +27,14 @@ const Hero = () => {
             <span className="text-terracota">Patria Nueva</span>
           </h1>
           
-          <p className="text-xl md:text-2xl text-cream font-light mb-12 max-w-4xl mx-auto leading-relaxed">
+          <p className="text-xl md:text-2xl text-cream font-light mb-8 max-w-4xl mx-auto leading-relaxed">
             "Un hermoso pueblo en el corazón de Hidalgo, donde la tradición y la modernidad se encuentran."
           </p>
+
+          {/* Carousel shown below tagline on mobile */}
+          <div className="mb-10 md:hidden">
+            <HeroCarousel />
+          </div>
 
           <div className="flex flex-col sm:flex-row gap-6 justify-center items-center mb-16">
             <button
@@ -69,7 +74,7 @@ const Hero = () => {
           </div>
           </div>
 
-          <div className="mb-10 md:mb-0 md:w-1/2 w-full">
+          <div className="hidden md:block md:mb-0 md:w-1/2 w-full">
             <HeroCarousel />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- restyle header with a solid multi‑color gradient
- modernize mobile menu background
- show hero carousel directly under the intro text on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524a3da2748332b5710c2814e7bb1b