### PR TITLE
Make email server optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# EMAIL_HOST=smtp.gmail.com
+# EMAIL_PORT=587
+EMAIL_USER=user@example.com
+EMAIL_PASS=yourpassword
+# Si no especificas EMAIL_HOST se usará Gmail automáticamente
+EMAIL_TO=l21200651@pachuca.tecnm.mx
+PORT=3001
+# VITE_API_URL=https://api.example.com
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Patria Nueva Website
+
+Este proyecto es un sitio web construido con Vite y React. Ahora incluye un pequeño servidor de Express para manejar el formulario de contacto y la suscripción por correo.
+
+## Configuración del servidor de correo
+
+El servidor utiliza `nodemailer` para enviar correos. Configure las siguientes variables de entorno antes de iniciar el servidor:
+
+- `EMAIL_HOST` – Servidor SMTP. Si no se define se usará Gmail automáticamente.
+- `EMAIL_PORT` – Puerto SMTP (opcional, por defecto 587).
+- `EMAIL_USER` – Usuario de la cuenta remitente.
+- `EMAIL_PASS` – Contraseña o token de la cuenta remitente.
+- `EMAIL_TO`   – Dirección que recibirá los mensajes (por defecto `l21200651@pachuca.tecnm.mx`).
+- `PORT`       – Puerto en el que se ejecutará el servidor (opcional, por defecto 3001).
+- `VITE_API_URL` – (opcional) URL base del API cuando el front y el servidor están en dominios distintos.
+
+Recuerda que debes establecer `EMAIL_USER` y `EMAIL_PASS` con las credenciales de la cuenta desde la que se enviarán los correos.
+
+Copie el archivo `.env.example` como `.env` y ajuste los valores según su proveedor de correo.
+
+## Comandos útiles
+
+- `npm run dev`     – Inicia Vite para desarrollo.
+- `npm run server`  – Inicia el servidor Express.
+- `npm run build`   – Compila la aplicación para producción.
+- `npm run lint`    – Ejecuta ESLint.
+
+Los formularios de contacto y suscripción envían datos a `/api/*` y el servidor
+enviará un mensaje de confirmación a la dirección ingresada.
+Si el servidor se aloja en un dominio distinto, defina `VITE_API_URL` en un
+archivo `.env` para apuntar a dicho dominio (por ejemplo
+`https://midominio.com`).

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "server": "node server.js",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"
@@ -12,7 +13,10 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "nodemailer": "^6.9.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,87 @@
+import express from 'express';
+import nodemailer from 'nodemailer';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const {
+  EMAIL_HOST,
+  EMAIL_PORT,
+  EMAIL_USER,
+  EMAIL_PASS,
+  EMAIL_TO = 'l21200651@pachuca.tecnm.mx',
+} = process.env;
+
+let transporter;
+
+// Si no se define un servidor SMTP se asume Gmail por defecto
+if (!EMAIL_HOST && EMAIL_USER && EMAIL_PASS) {
+  transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: { user: EMAIL_USER, pass: EMAIL_PASS },
+  });
+} else {
+  transporter = nodemailer.createTransport({
+    host: EMAIL_HOST || 'smtp.gmail.com',
+    port: EMAIL_PORT ? Number(EMAIL_PORT) : 587,
+    secure: false,
+    auth: EMAIL_USER && EMAIL_PASS ? { user: EMAIL_USER, pass: EMAIL_PASS } : undefined,
+  });
+}
+
+app.post('/api/contact', async (req, res) => {
+  const { nombre, email, telefono, asunto, mensaje } = req.body;
+  try {
+    await transporter.sendMail({
+      from: email,
+      to: EMAIL_TO,
+      subject: `Contacto: ${asunto}`,
+      text: `Nombre: ${nombre}\nEmail: ${email}\nTelefono: ${telefono}\n\n${mensaje}`,
+    });
+    if (email) {
+      await transporter.sendMail({
+        from: EMAIL_USER,
+        to: email,
+        subject: 'Hemos recibido tu mensaje',
+        text: 'Gracias por contactarnos. En breve te responderemos.',
+      });
+    }
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Error sending contact email:', err);
+    res.status(500).json({ success: false });
+  }
+});
+
+app.post('/api/subscribe', async (req, res) => {
+  const { email } = req.body;
+  try {
+    await transporter.sendMail({
+      from: EMAIL_USER,
+      to: EMAIL_TO,
+      subject: 'Nuevo suscriptor',
+      text: `Nuevo correo suscrito: ${email}`,
+    });
+
+    if (email) {
+      await transporter.sendMail({
+        from: EMAIL_USER,
+        to: email,
+        subject: 'Bienvenido a Patria Nueva',
+        text: 'Gracias por suscribirte a nuestro boletín.',
+      });
+    }
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Error sending subscription email:', err);
+    res.status(500).json({ success: false });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/components/Anuncios.tsx
+++ b/src/components/Anuncios.tsx
@@ -78,9 +78,15 @@ const Anuncios: React.FC = () => {
     e.preventDefault();
     if (!emailSuscripcion.trim()) return;
 
-    console.log('Email suscrito:', emailSuscripcion);
-
     try {
+      const base = import.meta.env.VITE_API_URL || '';
+      const res = await fetch(`${base}/api/subscribe`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: emailSuscripcion }),
+      });
+      if (!res.ok) throw new Error('Error');
+
       setSuscripcionExitosa(true);
       setEmailSuscripcion('');
     } catch (error) {

--- a/src/components/Contacto.tsx
+++ b/src/components/Contacto.tsx
@@ -20,13 +20,24 @@ const Contacto = () => {
     }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const body = `Nombre: ${formData.nombre}%0A` +
-      `Teléfono: ${formData.telefono}%0A%0A${formData.mensaje}`;
-    const mailto = `mailto:contacto@patrianueva.gob.mx?subject=${encodeURIComponent(formData.asunto)}&body=${encodeURIComponent(body)}`;
-    window.location.href = mailto;
-    setFormData({ nombre: '', email: '', telefono: '', asunto: '', mensaje: '' });
+    try {
+      const base = import.meta.env.VITE_API_URL || '';
+      const res = await fetch(`${base}/api/contact`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      if (!res.ok) throw new Error('Error');
+      setStatus('success');
+      setFormData({ nombre: '', email: '', telefono: '', asunto: '', mensaje: '' });
+    } catch (err) {
+      console.error('Error al enviar mensaje:', err);
+      setStatus('error');
+    }
   };
 
   const abrirMapa = () => {
@@ -258,12 +269,23 @@ const Contacto = () => {
               >
                 <Send size={20} />
                 <span>Enviar Mensaje</span>
-              </button>
-            </form>
+            </button>
+          </form>
 
-            <p className="text-gray-600 text-sm mt-4 text-center">
-              * Campos obligatorios. Responderemos a tu mensaje dentro de 24 horas.
+          {status === 'success' && (
+            <p className="text-green-600 text-center mt-4">
+              Mensaje enviado exitosamente.
             </p>
+          )}
+          {status === 'error' && (
+            <p className="text-red-600 text-center mt-4">
+              Hubo un error al enviar el mensaje.
+            </p>
+          )}
+
+          <p className="text-gray-600 text-sm mt-4 text-center">
+            * Campos obligatorios. Responderemos a tu mensaje dentro de 24 horas.
+          </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- make email host optional in the Express server and fall back to Gmail
- document that email host and port are optional and credentials are required
- clarify optional environment variables in `.env.example`
- send confirmation emails to people who contact or subscribe

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525cfad5fc8332b2d2dc1ddba39613