### PR TITLE
Mantener modales en posicion de clic

### DIFF
--- a/src/components/Anuncios.tsx
+++ b/src/components/Anuncios.tsx
@@ -27,6 +27,7 @@ const Anuncios: React.FC = () => {
 
   const [modalAbierto, setModalAbierto] = useState(false);
   const [anuncioSeleccionado, setAnuncioSeleccionado] = useState<Anuncio | null>(null);
+  const [modalOffset, setModalOffset] = useState(0);
   const [emailSuscripcion, setEmailSuscripcion] = useState('');
   const [suscripcionExitosa, setSuscripcionExitosa] = useState(false);
   const [mostrarSuscripcion, setMostrarSuscripcion] = useState(false);
@@ -63,8 +64,9 @@ const Anuncios: React.FC = () => {
   ];
 
   // Funciones de UI
-  const abrirModal = (anuncio: Anuncio) => {
+  const abrirModal = (anuncio: Anuncio, offset: number) => {
     setAnuncioSeleccionado(anuncio);
+    setModalOffset(offset);
     setModalAbierto(true);
   };
 
@@ -200,7 +202,12 @@ const Anuncios: React.FC = () => {
                   {anuncio.resumen || 'Haz clic para ver más detalles sobre este anuncio.'}
                 </p>
                 <button
-                  onClick={() => abrirModal(anuncio)}
+                  onClick={(e) =>
+                    abrirModal(
+                      anuncio,
+                      (e.currentTarget as HTMLElement).getBoundingClientRect().top
+                    )
+                  }
                   className="w-full bg-terracota hover:bg-opacity-90 text-white py-3 px-4 rounded-lg font-semibold flex items-center justify-center space-x-2 transition-colors duration-300"
                 >
                   <Info size={18} />
@@ -213,7 +220,10 @@ const Anuncios: React.FC = () => {
 
         {/* Modal de Anuncio */}
         {modalAbierto && anuncioSeleccionado && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div
+            className="fixed inset-0 bg-black bg-opacity-50 flex items-start justify-center p-4 z-50"
+            style={{ paddingTop: modalOffset }}
+          >
             {/* Fondo general del modal (verde transparente) */}
             <div className="rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto bg-olive-green/20 relative shadow-2xl backdrop-blur-sm">
               {/* Close Button */}

--- a/src/components/Eventos.tsx
+++ b/src/components/Eventos.tsx
@@ -17,6 +17,7 @@ const Eventos = () => {
   const ref = useScrollAnimation<HTMLDivElement>();
   const [modalAbierto, setModalAbierto] = useState(false);
   const [eventoSeleccionado, setEventoSeleccionado] = useState<Evento | null>(null);
+  const [modalOffset, setModalOffset] = useState(0);
 
   const eventImagesMap: Record<number, string[]> = {};
   const imgs = import.meta.glob('../assets/eventos-carousel/evento*/*.{jpg,jpeg,png,webp}', {
@@ -103,8 +104,9 @@ const Eventos = () => {
     }
   ];
 
-  const abrirModal = (evento: Evento) => {
+  const abrirModal = (evento: Evento, offset: number) => {
     setEventoSeleccionado(evento);
+    setModalOffset(offset);
     setModalAbierto(true);
   };
 
@@ -130,7 +132,12 @@ const Eventos = () => {
           {eventos.map((evento) => (
             <div
               key={evento.id}
-              onClick={() => abrirModal(evento)}
+              onClick={(e) =>
+                abrirModal(
+                  evento,
+                  (e.currentTarget as HTMLElement).getBoundingClientRect().top
+                )
+              }
               className="cursor-pointer bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
             >
               <div className="relative h-48">
@@ -166,7 +173,10 @@ const Eventos = () => {
           ))}
         </div>
         {modalAbierto && eventoSeleccionado && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div
+            className="fixed inset-0 bg-black bg-opacity-50 flex items-start justify-center p-4 z-50"
+            style={{ paddingTop: modalOffset }}
+          >
             <div className="bg-white bg-opacity-80 backdrop-blur-md rounded-2xl max-w-2xl w-full">
               <div className="relative">
                 <button

--- a/src/components/Historia.tsx
+++ b/src/components/Historia.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Clock, MapPin, Users, Book } from 'lucide-react';
+import React, { useState } from 'react';
+import { Clock, MapPin, Users, Book, X } from 'lucide-react';
 import useScrollAnimation from '../hooks/useScrollAnimation';
 import ImageCarousel from './ImageCarousel';
 
@@ -19,6 +19,9 @@ const historiaCarouselImages = Object.values(
 
 const Historia = () => {
   const ref = useScrollAnimation<HTMLDivElement>();
+  const [modalAbierto, setModalAbierto] = useState(false);
+  const [imagenSeleccionada, setImagenSeleccionada] = useState<string | null>(null);
+  const [modalOffset, setModalOffset] = useState(0);
   return (
     <div ref={ref} className="scroll-animation py-20 bg-cream">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -130,10 +133,36 @@ const Historia = () => {
                   key={idx}
                   src={src}
                   alt={`Historia ${idx + 1}`}
-                  className="w-full h-48 object-cover rounded-2xl shadow-md"
+                  className="w-full h-48 object-cover rounded-2xl shadow-md cursor-pointer"
+                  onClick={(e) => {
+                    setImagenSeleccionada(src);
+                    setModalOffset((e.currentTarget as HTMLImageElement).getBoundingClientRect().top);
+                    setModalAbierto(true);
+                  }}
                 />
               ))}
             </div>
+
+            {modalAbierto && imagenSeleccionada && (
+              <div
+                className="fixed inset-0 bg-black bg-opacity-50 flex items-start justify-center p-4 z-50"
+                style={{ paddingTop: modalOffset }}
+              >
+                <div className="relative">
+                  <button
+                    onClick={() => setModalAbierto(false)}
+                    className="absolute top-2 right-2 bg-black/40 text-white p-2 rounded-full hover:bg-black/70"
+                  >
+                    <X size={20} />
+                  </button>
+                  <img
+                    src={imagenSeleccionada}
+                    alt="Imagen seleccionada"
+                    className="max-h-[80vh] max-w-[90vw] object-contain rounded-lg"
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ajusta `Historia` para que las fotos abran el modal en la misma posición de la página

## Testing
- `npm run lint` *(falla: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685495eddec08332a4ce31a831525ac0