### PR TITLE
Implement auto-close for modals on scroll

### DIFF
--- a/src/components/Anuncios.tsx
+++ b/src/components/Anuncios.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Bell,
   Calendar,
@@ -70,10 +70,18 @@ const Anuncios: React.FC = () => {
     setModalAbierto(true);
   };
 
-  const cerrarModal = () => {
-    setModalAbierto(false);
-    setAnuncioSeleccionado(null);
-  };
+const cerrarModal = () => {
+  setModalAbierto(false);
+  setAnuncioSeleccionado(null);
+};
+
+  // Cerrar el modal al hacer scroll
+  useEffect(() => {
+    if (!modalAbierto) return;
+    const handleScroll = () => cerrarModal();
+    window.addEventListener('scroll', handleScroll, { once: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [modalAbierto]);
 
   // Suscripción
   const manejarSuscripcion = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/Eventos.tsx
+++ b/src/components/Eventos.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Calendar, Music, X } from 'lucide-react';
 import useScrollAnimation from '../hooks/useScrollAnimation';
 
@@ -110,10 +110,18 @@ const Eventos = () => {
     setModalAbierto(true);
   };
 
-  const cerrarModal = () => {
-    setModalAbierto(false);
-    setEventoSeleccionado(null);
-  };
+const cerrarModal = () => {
+  setModalAbierto(false);
+  setEventoSeleccionado(null);
+};
+
+  // Cerrar el modal cuando el usuario hace scroll
+  useEffect(() => {
+    if (!modalAbierto) return;
+    const handleScroll = () => cerrarModal();
+    window.addEventListener('scroll', handleScroll, { once: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [modalAbierto]);
 
   return (
     <div ref={ref} className="scroll-animation py-20 bg-olive-green">

--- a/src/components/Historia.tsx
+++ b/src/components/Historia.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Clock, MapPin, Users, Book, X } from 'lucide-react';
 import useScrollAnimation from '../hooks/useScrollAnimation';
 import ImageCarousel from './ImageCarousel';
@@ -22,6 +22,14 @@ const Historia = () => {
   const [modalAbierto, setModalAbierto] = useState(false);
   const [imagenSeleccionada, setImagenSeleccionada] = useState<string | null>(null);
   const [modalOffset, setModalOffset] = useState(0);
+
+  // Cerrar el modal si el usuario hace scroll
+  useEffect(() => {
+    if (!modalAbierto) return;
+    const handleScroll = () => setModalAbierto(false);
+    window.addEventListener('scroll', handleScroll, { once: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [modalAbierto]);
   return (
     <div ref={ref} className="scroll-animation py-20 bg-cream">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -84,10 +84,16 @@ const ImageCarousel: React.FC<ImageCarouselProps> = ({ images, className, imgCla
     return () => clearInterval(id);
   }, [images, paused]);
 
-  // Keep the modal visible while the user scrolls by removing
-  // the previous scroll listener that closed the modal when it
-  // moved out of view. The modal uses fixed positioning, so it
-  // naturally stays on screen and "follows" the user.
+  // Close the modal if the user scrolls the page
+  useEffect(() => {
+    if (!modalOpen) return;
+    const handleScroll = () => {
+      setModalOpen(false);
+      setPaused(false);
+    };
+    window.addEventListener('scroll', handleScroll, { once: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [modalOpen]);
 
   if (images.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- close `ImageCarousel` modal if user scrolls
- auto-close Historia, Anuncios and Eventos modals on scroll

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68549dadaea483328b5c4191eabf47a8