### PR TITLE
Implement auto-close at next section

### DIFF
--- a/src/components/Anuncios.tsx
+++ b/src/components/Anuncios.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Bell,
   Calendar,
@@ -70,10 +70,29 @@ const Anuncios: React.FC = () => {
     setModalAbierto(true);
   };
 
-  const cerrarModal = () => {
-    setModalAbierto(false);
-    setAnuncioSeleccionado(null);
-  };
+const cerrarModal = () => {
+  setModalAbierto(false);
+  setAnuncioSeleccionado(null);
+};
+
+  // Cerrar el modal al llegar a la siguiente sección desplazándose hacia abajo
+  useEffect(() => {
+    if (!modalAbierto) return;
+    const nextEl = document.querySelector<HTMLElement>('#eventos');
+    if (!nextEl) return;
+    const nextTop = nextEl.offsetTop;
+    let prevY = window.scrollY;
+    const handleScroll = () => {
+      const currY = window.scrollY;
+      if (currY > prevY && currY + window.innerHeight >= nextTop) {
+        cerrarModal();
+        window.removeEventListener('scroll', handleScroll);
+      }
+      prevY = currY;
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [modalAbierto]);
 
   // Suscripción
   const manejarSuscripcion = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -240,6 +259,7 @@ const Anuncios: React.FC = () => {
                 images={anuncioSeleccionado.imagenes ?? [anuncioSeleccionado.imagen]}
                 className="w-full h-[400px]" // Altura fija para el carrusel
                 imgClassName="object-contain"
+                nextSectionId="#eventos"
               />
 
               {/* Contenido del anuncio dentro del modal con fondo verde transparente y TEXTO CLARO */}

--- a/src/components/Eventos.tsx
+++ b/src/components/Eventos.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Calendar, Music, X } from 'lucide-react';
 import useScrollAnimation from '../hooks/useScrollAnimation';
 
@@ -110,10 +110,29 @@ const Eventos = () => {
     setModalAbierto(true);
   };
 
-  const cerrarModal = () => {
-    setModalAbierto(false);
-    setEventoSeleccionado(null);
-  };
+const cerrarModal = () => {
+  setModalAbierto(false);
+  setEventoSeleccionado(null);
+};
+
+  // Cerrar el modal al llegar a la siguiente sección desplazándose hacia abajo
+  useEffect(() => {
+    if (!modalAbierto) return;
+    const nextEl = document.querySelector<HTMLElement>('#servicios');
+    if (!nextEl) return;
+    const nextTop = nextEl.offsetTop;
+    let prevY = window.scrollY;
+    const handleScroll = () => {
+      const currY = window.scrollY;
+      if (currY > prevY && currY + window.innerHeight >= nextTop) {
+        cerrarModal();
+        window.removeEventListener('scroll', handleScroll);
+      }
+      prevY = currY;
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [modalAbierto]);
 
   return (
     <div ref={ref} className="scroll-animation py-20 bg-olive-green">

--- a/src/components/Historia.tsx
+++ b/src/components/Historia.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Clock, MapPin, Users, Book, X } from 'lucide-react';
 import useScrollAnimation from '../hooks/useScrollAnimation';
 import ImageCarousel from './ImageCarousel';
@@ -22,6 +22,25 @@ const Historia = () => {
   const [modalAbierto, setModalAbierto] = useState(false);
   const [imagenSeleccionada, setImagenSeleccionada] = useState<string | null>(null);
   const [modalOffset, setModalOffset] = useState(0);
+
+  // Cerrar el modal al llegar a la siguiente sección desplazándose hacia abajo
+  useEffect(() => {
+    if (!modalAbierto) return;
+    const nextEl = document.querySelector<HTMLElement>('#anuncios');
+    if (!nextEl) return;
+    const nextTop = nextEl.offsetTop;
+    let prevY = window.scrollY;
+    const handleScroll = () => {
+      const currY = window.scrollY;
+      if (currY > prevY && currY + window.innerHeight >= nextTop) {
+        setModalAbierto(false);
+        window.removeEventListener('scroll', handleScroll);
+      }
+      prevY = currY;
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [modalAbierto]);
   return (
     <div ref={ref} className="scroll-animation py-20 bg-cream">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -121,6 +140,7 @@ const Historia = () => {
                 images={historiaCarouselImages}
                 className="w-full h-64 md:h-80 rounded-2xl overflow-hidden shadow-lg"
                 imgClassName="w-full h-full object-contain rounded-2xl"
+                nextSectionId="#anuncios"
               />
               <p className="text-center text-gray-600 text-sm mt-2">
                 Para visualizar las imágenes con mayor detalle, pueden hacer clic sobre cualquiera de ellas.

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -5,9 +5,10 @@ interface ImageCarouselProps {
   images: string[];
   className?: string;
   imgClassName?: string;
+  nextSectionId?: string;
 }
 
-const ImageCarousel: React.FC<ImageCarouselProps> = ({ images, className, imgClassName }) => {
+const ImageCarousel: React.FC<ImageCarouselProps> = ({ images, className, imgClassName, nextSectionId }) => {
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -84,10 +85,25 @@ const ImageCarousel: React.FC<ImageCarouselProps> = ({ images, className, imgCla
     return () => clearInterval(id);
   }, [images, paused]);
 
-  // Keep the modal visible while the user scrolls by removing
-  // the previous scroll listener that closed the modal when it
-  // moved out of view. The modal uses fixed positioning, so it
-  // naturally stays on screen and "follows" the user.
+  // Cerrar el modal al llegar a la siguiente sección desplazándose hacia abajo
+  useEffect(() => {
+    if (!modalOpen || !nextSectionId) return;
+    const nextEl = document.querySelector<HTMLElement>(nextSectionId);
+    if (!nextEl) return;
+    const nextTop = nextEl.offsetTop;
+    let prevY = window.scrollY;
+    const handleScroll = () => {
+      const currY = window.scrollY;
+      if (currY > prevY && currY + window.innerHeight >= nextTop) {
+        setModalOpen(false);
+        setPaused(false);
+        window.removeEventListener('scroll', handleScroll);
+      }
+      prevY = currY;
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [modalOpen, nextSectionId]);
 
   if (images.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- detect scrolling past the next section to close modals
- pass `nextSectionId` to `ImageCarousel` in Historia and Anuncios
- close Historia, Anuncios and Eventos modals when the next section appears

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549dadaea483328b5c4191eabf47a8